### PR TITLE
feature: add restart connector query options

### DIFF
--- a/restart_connector.go
+++ b/restart_connector.go
@@ -5,12 +5,17 @@ import (
 	"strconv"
 )
 
-// ListConnectorsOptions describe the available options to list connectors. Either Status or Info must be set to true.
+// RestartConnectorOptions describe the available options to restart connectors.
 type RestartConnectorOptions struct {
+	// Specifies whether to restart the connector instance and task instances
+	// or just the connector instance. Default is false.
 	IncludeTasks bool
-	OnlyFailed   bool
+	// Specifies whether to restart just the instances with a FAILED status
+	// or all instances. Default is false.
+	OnlyFailed bool
 }
 
+// // RestartConnector restart the connector.
 func (c *Client) RestartConnector(ctx context.Context, connectorName string, options RestartConnectorOptions) error {
 	response, err := c.client.NewRequest().
 		SetContext(ctx).

--- a/restart_connector.go
+++ b/restart_connector.go
@@ -2,13 +2,24 @@ package connect
 
 import (
 	"context"
+	"strconv"
 )
 
-func (c *Client) RestartConnector(ctx context.Context, connectorName string) error {
+// ListConnectorsOptions describe the available options to list connectors. Either Status or Info must be set to true.
+type RestartConnectorOptions struct {
+	IncludeTasks bool
+	OnlyFailed   bool
+}
+
+func (c *Client) RestartConnector(ctx context.Context, connectorName string, options RestartConnectorOptions) error {
 	response, err := c.client.NewRequest().
 		SetContext(ctx).
 		SetError(ApiError{}).
 		SetPathParam("connector", connectorName).
+		SetQueryParams(map[string]string{
+			"includeTasks": strconv.FormatBool(options.IncludeTasks),
+			"onlyFailed":   strconv.FormatBool(options.OnlyFailed),
+		}).
 		Post("/connectors/{connector}/restart")
 	if err != nil {
 		return err

--- a/restart_connector_test.go
+++ b/restart_connector_test.go
@@ -1,0 +1,74 @@
+package connect
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRestartConnectors tests the success case for restarting connectors in a connect cluster.
+func TestRestartConnectors(t *testing.T) {
+	baseURL := "https://fake.api"
+
+	tests := []struct {
+		title   string
+		url     string
+		options RestartConnectorOptions
+	}{
+		{
+			title:   "default",
+			url:     baseURL + "/connectors/my-connector/restart",
+			options: RestartConnectorOptions{},
+		},
+		{
+			title:   "includeTasks=false",
+			url:     baseURL + "/connectors/my-connector/restart?includeTasks=false&onlyFailed=false",
+			options: RestartConnectorOptions{IncludeTasks: false},
+		},
+		{
+			title:   "onlyFailed=false",
+			url:     baseURL + "/connectors/my-connector/restart?includeTasks=false&onlyFailed=false",
+			options: RestartConnectorOptions{OnlyFailed: false},
+		},
+		{
+			title:   "both false",
+			url:     baseURL + "/connectors/my-connector/restart?includeTasks=false&onlyFailed=false",
+			options: RestartConnectorOptions{IncludeTasks: false, OnlyFailed: false},
+		},
+		{
+			title:   "include tasks",
+			url:     baseURL + "/connectors/my-connector/restart?includeTasks=true&onlyFailed=false",
+			options: RestartConnectorOptions{IncludeTasks: true},
+		},
+		{
+			title:   "include only failed",
+			url:     baseURL + "/connectors/my-connector/restart?includeTasks=false&onlyFailed=true",
+			options: RestartConnectorOptions{OnlyFailed: true},
+		},
+		{
+			title:   "include both",
+			url:     baseURL + "/connectors/my-connector/restart?includeTasks=true&onlyFailed=true",
+			options: RestartConnectorOptions{IncludeTasks: true, OnlyFailed: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+
+			c := NewClient(WithHost(baseURL))
+
+			httpmock.ActivateNonDefault(c.client.GetClient())
+			defer httpmock.DeactivateAndReset()
+
+			httpmock.RegisterResponder("POST", tt.url,
+				newJsonStringResponder(http.StatusOK,
+					`{"name": "my-connector","connector": {"state": "RUNNING","worker_id": "fakehost1:8083"},"tasks":[{"id": 0,"state": "RUNNING","worker_id": "fakehost2:8083"},{"id": 1,"state": "RESTARTING","worker_id": "fakehost3:8083"},{"id": 2,"state": "RESTARTING","worker_id": "fakehost1:8083"}]}`))
+
+			err := c.RestartConnector(context.Background(), "my-connector", tt.options)
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
The [restart connector endpoint](https://docs.confluent.io/platform/current/connect/references/restapi.html#tasks) allows us to specify additional query options in the request to restart tasks, and to restart only failed.

This is a breaking change in the sense that `RestartConnector()` function now accepts as additional `RestartConnectorOptions` parameter.