### PR TITLE
refactor!: use same struct for list and get responses

### DIFF
--- a/list_connectors.go
+++ b/list_connectors.go
@@ -41,11 +41,12 @@ func (l *ListConnectorsOptions) Validate() error {
 
 // ListConnectorsResponseExpanded is the response to /connectors if the expand query parameters are set.
 type ListConnectorsResponseExpanded struct {
-	Info   ListConnectorsResponseExpandedInfo   `json:"info"`
-	Status ListConnectorsResponseExpandedStatus `json:"status"`
+	Info   ConnectorInfo      `json:"info"`
+	Status ConnectorStateInfo `json:"status"`
 }
 
 // ListConnectorsResponseExpandedInfo represents the Info object for described connectors.
+// Deprecated: Use ConnectorInfo instead, the same information is available there
 type ListConnectorsResponseExpandedInfo struct {
 	Name   string            `json:"name"`
 	Config map[string]string `json:"config"`
@@ -57,6 +58,7 @@ type ListConnectorsResponseExpandedInfo struct {
 }
 
 // ListConnectorsResponseExpandedStatus represents the Status object for described connectors.
+// Deprecated: Use ConnectorStateInfo instead, the same information is available there
 type ListConnectorsResponseExpandedStatus struct {
 	Name      string `json:"name"`
 	Connector struct {


### PR DESCRIPTION
When the response is the same data, use the same struct for list and single detail operation.

BREAKING CHANGE:

Deprecate ListConnectorsResponseExpandedInfo and
ListConnectorsResponseExpandedStatus since the same response is availabe in other interface and working with them will be easier